### PR TITLE
Fixed type conversions: Removed unnecessary float to double conversion

### DIFF
--- a/adma_ros2_driver/include/adma_ros2_driver/parser/parser_utils.hpp
+++ b/adma_ros2_driver/include/adma_ros2_driver/parser/parser_utils.hpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-const float PI=3.1415926535897932384626433832795028841971f;
+const double PI=3.1415926535897932384626433832795028841971;
 
 bool getbit(unsigned char byte, int position);
-float getScaledValue(int32_t rawValue, float lsbFactor);
+double getScaledValue(int32_t rawValue, double lsbFactor);

--- a/adma_ros2_driver/src/parser/parser_utils.cpp
+++ b/adma_ros2_driver/src/parser/parser_utils.cpp
@@ -10,7 +10,7 @@ bool getbit(unsigned char byte, int position) // position in range 0-7
     return (byte >> position) & 0x1;
 }
 
-float getScaledValue(int32_t rawValue, float lsbFactor)
+double getScaledValue(int32_t rawValue, double lsbFactor)
 {
-    return rawValue * lsbFactor;
+    return double(rawValue) * lsbFactor;
 }


### PR DESCRIPTION
The `getScaledValue` function previously returned a float, which was implicitly converted back to a double value, because all filled messages (except AdmaDataDelta) use float64 values only. In this process, precision was lost.

We need the precision of a double value because the precision loss is otherwise visible in GNSS and INS lateral and longitudinal absolute positions.